### PR TITLE
Fix wp-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
     libpng-dev \
+    less \
     gnupg gnupg1 gnupg2
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/  \


### PR DESCRIPTION
WP CLI needs `less`. This doesn't fix the "not allowed as root error" . Add `--allow-root` to by pass the error. A separate solution must be found for that.